### PR TITLE
Add environment-based config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and adjust values as needed
+DB_URL=jdbc:postgresql://localhost:5432/asset_db
+DB_USER=postgres
+DB_PASSWORD=change_me
+SHOW_SQL=false

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Load environment variables from .env if present.
+if [ -f .env ]; then
+  set -o allexport
+  source .env
+  set +o allexport
+fi
+
+# Start the application
+./mvnw spring-boot:run "$@"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,14 +1,14 @@
 spring.application.name=Asset Management App
 
 # ========== DATABASE CONNECTION ==========
-spring.datasource.url=jdbc:postgresql://localhost:5432/asset_db
-spring.datasource.username=postgres
-spring.datasource.password=0318
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/asset_db}
+spring.datasource.username=${DB_USER:postgres}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # ========== JPA SETTINGS ==========
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+spring.jpa.show-sql=${SHOW_SQL:false}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # ========== SERVER SETTINGS ==========


### PR DESCRIPTION
## Summary
- load datasource credentials from environment variables
- disable SQL logging by default using env override
- provide example `.env` file and startup script

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686007c434688321bb21346ec319b252