### PR TITLE
Add Launch4j build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ Clone the repo and start the app:
 git clone https://github.com/nicholasC03/asset-management-app.git
 cd asset-management-app
 ./mvnw spring-boot:run
+```
+
+### Build Windows Executable
+
+Run the following command to create a `.exe` launcher using Launch4j:
+
+```bash
+./mvnw package
+```
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,28 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.akathist.maven.plugins.launch4j</groupId>
+                <artifactId>launch4j-maven-plugin</artifactId>
+                <version>2.6.0</version>
+                <executions>
+                    <execution>
+                        <id>launch4j</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>launch4j</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outfile>${project.build.directory}/${project.artifactId}.exe</outfile>
+                    <headerType>console</headerType>
+                    <jar>${project.build.directory}/${project.build.finalName}.jar</jar>
+                    <classPath>
+                        <mainClass>com.nick.assetmanagementapp.MainApp</mainClass>
+                    </classPath>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/nick/assetmanagementapp/MainApp.java
+++ b/src/main/java/com/nick/assetmanagementapp/MainApp.java
@@ -1,0 +1,7 @@
+package com.nick.assetmanagementapp;
+
+public class MainApp {
+    public static void main(String[] args) {
+        AssetManagementAppApplication.main(args);
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `MainApp` launcher class
- configure `launch4j-maven-plugin` to build a Windows executable
- document the `./mvnw package` build step

## Testing
- `./mvnw -q package` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ad83bfb9c8321881fa4ac2219f8aa